### PR TITLE
fix experimental::smartmatch warnings on 5.18+

### DIFF
--- a/lib/Mac/iPhoto/Exif.pm
+++ b/lib/Mac/iPhoto/Exif.pm
@@ -4,8 +4,6 @@ package Mac::iPhoto::Exif;
 
 use 5.010;
 use utf8;
-no if $] >= 5.017004, warnings => qw(experimental::smartmatch);
-
 use Moose;
 
 use Moose::Util::TypeConstraints;
@@ -18,6 +16,8 @@ use Unicode::Normalize;
 
 use Image::ExifTool;
 use Image::ExifTool::Location;
+
+no if $] >= 5.017004, warnings => qw(experimental::smartmatch);
 
 our $VERSION = "1.01";
 our $AUTHORITY = 'cpan:MAROS';

--- a/lib/Mac/iPhoto/Exif/Commandline.pm
+++ b/lib/Mac/iPhoto/Exif/Commandline.pm
@@ -4,7 +4,6 @@ package Mac::iPhoto::Exif::Commandline;
 
 use 5.010;
 use utf8;
-no if $] >= 5.017004, warnings => qw(experimental::smartmatch);
 
 use Moose;
 with qw(MooseX::Getopt);
@@ -13,6 +12,8 @@ extends qw(Mac::iPhoto::Exif);
 use Moose::Util::TypeConstraints;
 use Term::ANSIColor;
 use Scalar::Util qw(weaken);
+
+no if $] >= 5.017004, warnings => qw(experimental::smartmatch);
 
 has 'force' => (
     is                  => 'ro',


### PR DESCRIPTION
the "no if .., warnings => qw(experimental::smartmatch)" line had no
effect because it preceeds "use Moose*" lines.  Moose modules turn all
warnings back on, so these warnings must be turned off AFTER Moose
modules are loaded.  Fixed by moving these lines below all the "use"
lines.